### PR TITLE
Allow setting/clearing multiple cookies at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,25 @@ The extension(s) are responsible for 3 things:
 2. Removing cookies in the iframe when (fetch) requests return `Set-Cookie` headers with an empty value for a cookie
 3. Copying cookies from the editor --> the iframe. This is useful when working with authenticated APIs where you're already logged in for instance.
 
-## Testing
+## Testing unpublished extensions
+
+### Chrome
+
+1. Build the Chrome extension using `bun run build:chrome`
+2. Open the "Extensions" page
+3. Click "Load unpacked"
+4. Select the `chrome/` folder in the `dist/` folder
+5. Click "Inspect views `service worker`" to see its output (`console.log`s, exceptions etc.)
+
+### Firefox
+
+1. Build the Firefox extension using `bun run build:firefox`
+2. Open `about:debugging#/runtime/this-firefox` in Firefox
+3. Click "Load Temporary Add-on"
+4. Select the manifest from the `dist/` folder
+5. Click "Inspect" on the installed extension to see its output (`console.log`s, exceptions etc.)
+
+## Testing extension functionality
 
 To test the different aspects of the extensions, it's recommended to:
 

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "toddle",
   "description": "Browser extension for the toddle editor.",
-  "version": "2.3",
+  "version": "2.3.1",
   "icons": {
     "32": "icons/toddle_32x32.png",
     "64": "icons/toddle_64x64.png",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "toddle",
-  "version": "2.2",
+  "version": "2.3.1",
   "description": "Browser extension for the toddle editor.",
   "background": {
     "scripts": ["firefox/src/background.js"]

--- a/firefox/src/background.ts
+++ b/firefox/src/background.ts
@@ -82,8 +82,18 @@ browser.webRequest.onBeforeSendHeaders.addListener(
 browser.webRequest.onHeadersReceived.addListener(
   (info) => {
     if (info.responseHeaders) {
+      const setCookieHeader = info.responseHeaders.find(
+        (h) => h.name.toLowerCase() === 'set-cookie',
+      )
+      const setCookieHeaders = setCookieHeader?.value
+        // Firefox returns a string with all set-cookie cookies separated by newline \n
+        ?.split('\n')
+        .filter(Boolean)
+      if (!setCookieHeaders || setCookieHeaders.length === 0) {
+        return
+      }
       setCookies({
-        responseHeaders: info.responseHeaders,
+        setCookieHeaders,
         requestUrl: info.url,
         setCookie: (cookie) => browser.cookies.set(cookie),
         removeCookie: (cookie) => browser.cookies.remove(cookie),

--- a/firefox/src/install_notifier.ts
+++ b/firefox/src/install_notifier.ts
@@ -1,4 +1,5 @@
 let firefoxVersion = browser.runtime.getManifest().version
+console.log('firefoxVersion', firefoxVersion)
 
 // Notify the editor that the extension is installed
 window.postMessage(


### PR DESCRIPTION
Differentiate between Chrome and Firefox when handling `Set-Cookie` headers:
- Chrome: `info.responseHeaders` holds an array with potentially multiple `Set-Cookie` headers
- Firefox: `info.responseHeaders` holds a single `Set-Cookie` header with all cookies separated by newline `\n`

Improve README with test instructions for unpublished extensions