### PR TITLE
Fix manifest and build step for Firefox

### DIFF
--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -7,9 +7,8 @@
     "scripts": ["firefox/src/background.js"]
   },
   "icons": {
-    "32": "icons/icon-32x32.png",
-    "64": "icons/icon-64x64.png",
-    "128": "icons/icon-128x128.png"
+    "48": "icons/icon-48x48.png",
+    "96": "icons/icon-96x96.png"
   },
   "homepage_url": "https://toddle.dev",
   "permissions": ["cookies", "webRequest", "webRequestBlocking"],
@@ -20,5 +19,11 @@
       "js": ["firefox/src/install_notifier.js"],
       "run_at": "document_idle"
     }
-  ]
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{b369ea25-4d25-4ecb-81dd-b09da203176a}",
+      "strict_min_version": "109.0"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prebuild:chrome": "rm -rf dist/chrome && tsc --project tsconfig.chrome.json",
     "build:chrome": "cp chrome/manifest.json dist/chrome/ && cp -a chrome/icons dist/chrome && cd dist/ && zip -FSr chrome/chrome.zip chrome/",
     "prebuild:firefox": "rm -rf dist/firefox && tsc --project tsconfig.firefox.json",
-    "build:firefox": "cp firefox/manifest.json dist/firefox/ && cp -a firefox/icons dist/firefox && cd dist/ && zip -FSr firefox/firefox.zip firefox/",
+    "build:firefox": "cp firefox/manifest.json dist/firefox/ && cp -a firefox/icons dist/firefox && cd dist/firefox && zip -FSr firefox.zip .",
     "prettier": "prettier --check '*.json' '**/*.ts'",
     "prettier:write": "prettier --write '*.json' '**/*.ts'"
   }


### PR DESCRIPTION
After trying to submit the zip file from the `dist/` folder, it appeared there were a few things we were missing from the manifest:
- The referenced icons didn't exist
- The manifest required an extension id

Also, the zip file included a firefox/ folder with all files, but the manifest was required in the root of the zip file. That was fixed in the build step